### PR TITLE
The system-desc-id_implementation-id.json file was removed from the t…

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -253,7 +253,6 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 ***** <implementation_id>/
 ****** <arbitrary stuff>
 ***** <system_desc_id>/
-****** <system_desc_id>_<implementation_id>.json
 ****** README.md
 ****** setup.sh (one-time configuration script)
 ****** init_datasets.sh (one-time dataset init script)


### PR DESCRIPTION
...raining file-system tree in some previous round, we no longer know what the contents were intended to be, the config checker doesn't know anything about this file, and ignores it if it exists.  So removing from spec.