### PR TITLE
Anirban ghosh patch 1

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -403,7 +403,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | host_memory_capacity | Yes | 128GB | 384GB | 384GB
 | host_storage_type | Yes | SSD | SSD | SSD
 | host_storage_capacity | Yes | 1 200 GB + 1 50 GB | 800GB | 800GB
-| host_networking | Yes for datacenter inference or add accelerator interconnect |  | 1x 100GbE | 2x 200Gb IB
+| host_networking | Yes for datacenter power or add accelerator interconnect |  | 1x 100GbE | 2x 200Gb IB
 | host_networking_topology |  |  | N/A | N/A
 | host_memory_configuration |  |  | 12 x 32GB 2Rx4 PC4-2666V-R | 12 x 32GB 2Rx4 PC4-2666V-R
 | accelerators_per_node | Yes | 16 | 4 | 4
@@ -413,7 +413,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | accelerator_on-chip_memories |  |  | L1: 80x 128KB, L2: 6MB per chip | L1: 80x 128KB, L2: 6MB per chip 
 | accelerator_memory_configuration | Yes | HBM | HBM2 | HBM2
 | accelerator_memory_capacity | Yes | 32 GB | 32GB | 32GB
-| accelerator_interconnect | Yes for datacenter inference or add host interconnect |  | 6x 25GT/s NVLink | 4x 100GbE
+| accelerator_interconnect | Yes for datacenter power or add host interconnect |  | 6x 25GT/s NVLink | 4x 100GbE
 | accelerator_interconnect_topology |  |  | Direct | Mesh
 | cooling |  |  | Liquid | Air-cooled
 | hw_notes |  |  | I overclocked it! | Miscellaneous notes

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -403,7 +403,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | host_memory_capacity | Yes | 128GB | 384GB | 384GB
 | host_storage_type | Yes | SSD | SSD | SSD
 | host_storage_capacity | Yes | 1 200 GB + 1 50 GB | 800GB | 800GB
-| host_networking |  |  | N/A | N/A
+| host_networking | Yes for datacenter inference or add accelerator interconnect |  | 1x 100GbE | 2x 200Gb IB
 | host_networking_topology |  |  | N/A | N/A
 | host_memory_configuration |  |  | 12 x 32GB 2Rx4 PC4-2666V-R | 12 x 32GB 2Rx4 PC4-2666V-R
 | accelerators_per_node | Yes | 16 | 4 | 4
@@ -413,7 +413,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | accelerator_on-chip_memories |  |  | L1: 80x 128KB, L2: 6MB per chip | L1: 80x 128KB, L2: 6MB per chip 
 | accelerator_memory_configuration | Yes | HBM | HBM2 | HBM2
 | accelerator_memory_capacity | Yes | 32 GB | 32GB | 32GB
-| accelerator_interconnect |  |  | 6x 25GT/s NVLink | 6x 25GT/s NVLink
+| accelerator_interconnect | Yes for datacenter inference or add host interconnect |  | 6x 25GT/s NVLink | 4x 100GbE
 | accelerator_interconnect_topology |  |  | Direct | Mesh
 | cooling |  |  | Liquid | Air-cooled
 | hw_notes |  |  | I overclocked it! | Miscellaneous notes


### PR DESCRIPTION
Added changes to System JSON requirements to make Networking details a mandatory field for datacenter systems that submit power measurements.  Datacenter systems always come with required networking, and removing the networking components during a power run (like inference power runs) can artificially lower power consumption while not affecting perf. (since loadgen runs on the host).  Making this mandatory here and raising the definition on datacenter systems in the inference policies together ensure that the system whose power is being measured is appropriately populated to reflect the power consumption of a realistic system.  

