### PR TITLE
Clarify that the review committee *departs from* the rules.

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -108,7 +108,7 @@ should be explicitly incorporated into the rules through the normal process.
 
 MLPerf’s purpose is to produce fair and useful benchmark results.
 
-The MLPerf review committee reserves the right to depart from rules and/or
+The MLPerf review committee reserves the right to depart from these rules and/or
 exclude submissions that conflict with this purpose with a two-thirds (rounded
 up) vote by the submitters. For instance, if the schedule is discovered to be
 untenable in practice, it may be amended. If a submission is judged to be

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -108,7 +108,7 @@ should be explicitly incorporated into the rules through the normal process.
 
 MLPerf’s purpose is to produce fair and useful benchmark results.
 
-The MLPerf review committee reserves the right to amend these rules and/or
+The MLPerf review committee reserves the right to depart from rules and/or
 exclude submissions that conflict with this purpose with a two-thirds (rounded
 up) vote by the submitters. For instance, if the schedule is discovered to be
 untenable in practice, it may be amended. If a submission is judged to be


### PR DESCRIPTION
A technical fix split out from PR#90, since this part is missed in the alternative and is unlikely to be controversial.

The notion that a review committee may amend the rules (rather than depart from them) both contradicts the non-precedential framework laid out in section 2, and doesn't make sense in the context of multiple working groups.