### PR TITLE
Update to system json required fields for preview category

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -435,9 +435,9 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | system_name | Yes | tpu-v3 | 8ball | 8ball
 | number_of_nodes | Yes | 1 | 1 | 1
 | host_processors_per_node | Yes | 1 | 2 | 2
-| host_processor_model_name | Yes | Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
-| host_processor_core_count | Yes, or vcpu |  | 26 | 26
-| host_processor_vcpu_count | Yes, or core | 96 | |
+| host_processor_model_name | Yes ^1^| Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
+| host_processor_core_count | Yes^1^, or vcpu |  | 26 | 26
+| host_processor_vcpu_count | Yes^1^, or core ^1^| 96 | |
 | host_processor_frequency |  |  | 2000MHz | 2000MHz
 | host_processor_caches |  |  | L1: 32KB I + 32KB D per core, L2: 1MB I+D per core, L3: 37.75MB I+D per chip | L1: 32KB I + 32KB D per core, L2: 1MB I+D per core, L3: 37.75MB I+D per chip
 | host_processor_interconnect |  |  | 3x 10.6GT/s UPI | 3x 10.6GT/s UPI
@@ -464,7 +464,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | operating_system | Yes | Ubuntu 16.04 | Ubuntu 18.04.1 LTS | Ubuntu 18.04.1 LTS
 | sw_notes |  |  | extra notes here | extra notes here
 |===
-
+^1^ Optional for preview system submission. These fields must be updated in the system description json upon the public availability of the processor.
 
 ### <system_desc_id>_<implementation_id>_<scenario>.json metadata
 

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -435,7 +435,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | system_name | Yes | tpu-v3 | 8ball | 8ball
 | number_of_nodes | Yes | 1 | 1 | 1
 | host_processors_per_node | Yes | 1 | 2 | 2
-| host_processor_model_name | Yes ^1^| Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
+| host_processor_model_name | Yes | Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
 | host_processor_core_count | Yes^1^, or vcpu |  | 26 | 26
 | host_processor_vcpu_count | Yes^1^, or core ^1^| 96 | |
 | host_processor_frequency |  |  | 2000MHz | 2000MHz


### PR DESCRIPTION
Processor model and processor core count is not required in system_desc.json for preview systems. This PR is related to https://github.com/mlcommons/policies/issues/97