### PR TITLE
Update to system json required fields for preview

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -435,7 +435,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | system_name | Yes | tpu-v3 | 8ball | 8ball
 | number_of_nodes | Yes | 1 | 1 | 1
 | host_processors_per_node | Yes | 1 | 2 | 2
-| host_processor_model_name | Yes ^1^| Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
+| host_processor_model_name | Yes | Intel Skylake | Intel Xeon Platinum 8164 | Intel Xeon Platinum 8164 
 | host_processor_core_count | Yes^1^, or vcpu |  | 26 | 26
 | host_processor_vcpu_count | Yes^1^, or core ^1^| 96 | |
 | host_processor_frequency |  |  | 2000MHz | 2000MHz


### PR DESCRIPTION
Based on the discussion from Inference WG, meaningful response for "host_processor_model_name" field can be generic processor name that may not include processor model number for a preview submission. Updated PR changes reflect core count as option field for preview hardware.