### PR TITLE
Remove option to submit a hashed tarball

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -594,33 +594,6 @@ Submitters must run the compliance tests for their closed and network divisions 
 
 Refer to the documentation found under https://github.com/mlperf/inference/tree/master/compliance/nvidia
 
-### Submission Privacy
-
-Submitters may adopt the following procedure to ensure that their submission is shared only with others who have made valid submissions:
-
-By the submission deadline, the submitter will email the following items to submissions@mlcommons.org to show Proof of Work:
-
-- A URL to the location in public blob storage of an encrypted tarball containing the directory structure and files described in the <<directory-structure>> section above. Any storage mechanism that supports curl may be used.
-- A password to the encrypted tarball
-- A sha1sum of the tarball
-- The last two lines of submission_checker_log.txt as cursory evidence of a valid submission
-
-A simple script has been provided to facilitate this process: https://github.com/mlcommons/logging/blob/master/pack_submission.sh
-
-When the deadline is reached, repository access will be removed for everyone EXCEPT the following parties:
-
-- Chairs
-- Submitters who have submitted valid submissions
-
-For each submitted tarball, the results chair will then:
-
-- download the encrypted tarball
-- verify it matches the hash
-- decrypt the tarball
-- verify that it is a valid submission
-- add the submission to the repository
-- enable repository access for the submitter
-
 ## Review
 
 


### PR DESCRIPTION
This option is obsolete given the GUI submission process.