### PR TITLE
Update submission_rules.adoc

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -328,8 +328,8 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 ****** init_datasets.sh (one-time dataset init script)
 ****** run_and_time.sh (run the benchmark and produce a result)
 ** results/
-*** <system_desc_id>/
-**** <benchmark>/
+*** <benchmark>/
+**** <system_desc_id>_<implementation_id>/
 ***** result_<i>.txt   # log file
 
 System names and implementation names may be arbitrary. 


### PR DESCRIPTION
Is the indentation correct here / order of subdirectories It seems to me that for the subdirectories in the benchmarks/implementations/<systems_desc_id> the order in results needs to be modified to  results/<benchmark>/<system_desc_id>_<implementation_id>/result_<i>.txt The current naming in the results/ directory appears not be capable to distinguish between multiple implementations being run on a single system?