### PR TITLE
Missing bert in training benchmark names?

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -334,7 +334,7 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 
 System names and implementation names may be arbitrary. 
 
-Training benchmark directory names must be one of  { **resnet, ssd, maskrcnn, transformer, gnmt, ncf, minigo **}.
+Training benchmark directory names must be one of  { ** bert, gnmt, maskrcnn, minigo, ncf, resnet, ssd, transformer **}.
 
 #### HPC
 


### PR DESCRIPTION
Shouldn't bert be among the allowed training benchmark names? Also, I sorted the list in alphabetical order.