### PR TITLE
Training submission directory structure

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -321,12 +321,12 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 **** implementations/
 ***** <implementation_id>/
 ****** <arbitrary stuff>
-***** <system_desc_id>/
-****** <system_desc_id>_<implementation_id>.json
-****** README.md
-****** setup.sh (one-time configuration script)
-****** init_datasets.sh (one-time dataset init script)
-****** run_and_time.sh (run the benchmark and produce a result)
+****** <system_desc_id>/
+******* <system_desc_id>_<implementation_id>.json
+******* README.md
+******* setup.sh (one-time configuration script)
+******* init_datasets.sh (one-time dataset init script)
+******* run_and_time.sh (run the benchmark and produce a result)
 ** results/
 *** <system_desc_id>/
 **** <benchmark>/


### PR DESCRIPTION
It appears to me that the system description section in benchmarks/<bmname>/implementations/  need to be under each particular implementation_id as there is a risk that the same benchmark name run with different implementations on the same system may not use the same shell scripts etc. ?