### PR TITLE
Update MLPerf_Compatibility_Table.adoc

### DIFF
--- a/MLPerf_Compatibility_Table.adoc
+++ b/MLPerf_Compatibility_Table.adoc
@@ -6,18 +6,18 @@
 
 |===
 |Model |0.5 |0.6 |0.7 |1.0 |1.1 |2.0 |2.1
-|ResNet-50 v1.5 |X 5+|X |X
-|SSD-ResNet34 |X 4+|X |N/A |N/A
-|RetinaNet-ResNeXt50 5+|N/A |X |X
-|MaskRCNN |X 5+|X |X
-|NCF |X 5+|N/A |N/A
-|NMT |X 2+|X 3+|N/A |N/A
-|Transformer |X 2+|X 3+|N/A |N/A
-|MiniGo |X |X 4+|X |X
-|DLRM 2+|N/A 4+|X |X
-|BERT 3+|N/A 3+|X |X
-|RNN-T 3+|N/A |X 2+|X |X
-|3D U-Net 3+|N/A 3+|X |X
+|ResNet-50 v1.5 |X 6+|X 
+|SSD-ResNet34 |X 4+|X 2+|N/A 
+|RetinaNet-ResNeXt50 5+|N/A 2+|X 
+|MaskRCNN |X 6+|X 
+|NCF |X 6+|N/A 
+|NMT |X 2+|X 4+|N/A 
+|Transformer |X 2+|X 4+|N/A
+|MiniGo |X |X 5+|X 
+|DLRM 2+|N/A 5+|X 
+|BERT 3+|N/A 4+|X 
+|RNN-T 3+|N/A |X 3+|X 
+|3D U-Net 3+|N/A 4+|X 
 |===
 
 Metric: Time-to-train (measured in minutes)


### PR DESCRIPTION
Fix the v2.1 column to say that every v2.1 benchmark is compatible with v2.0. (there was a bug in the column delimiters)