### PR TITLE
Results post processing scripts

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -327,7 +327,7 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 ****** setup.sh (one-time configuration script)
 ****** init_datasets.sh (one-time dataset init script)
 ****** run_and_time.sh (run the benchmark and produce a result)
-****** (include any post-processing scripts used to make non-material changes to result logs)
+****** (include any post-processing scripts used to make changes to result logs)
 ** results/
 *** <system_desc_id>/
 **** <benchmark>/

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -327,6 +327,7 @@ A submission is for one code base for the benchmarks submitted. An org may make 
 ****** setup.sh (one-time configuration script)
 ****** init_datasets.sh (one-time dataset init script)
 ****** run_and_time.sh (run the benchmark and produce a result)
+****** (include any post-processing scripts used to make non-material changes to result logs)
 ** results/
 *** <system_desc_id>/
 **** <benchmark>/


### PR DESCRIPTION
It was discussed in the Training WG meeting on 02/09/2023 that for transparency, any post-processing scripts used to make cosmetic non-material changes on results logs should get included in submission.