### PR TITLE
Add system_type_specific field to system_desc

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -445,6 +445,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | submitter | Yes | Google | David Kanter | David Kanter
 | division | Yes | closed | Closed | Open
 | system_type | Yes | datacenter | datacenter | edge
+| system_type_specific | Yes^2^ | cloud | edge-server | edge-device
 | status | Yes | available | available | available
 |  |  |  |  |
 | system_name | Yes | tpu-v3 | 8ball | 8ball
@@ -482,6 +483,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 |===
 
 ^1^ Optional for preview system submission. These fields must be updated in the system description json upon the public availability of the processor.
+^2^ The valid values for `system_type_specific` are `cloud` and `on-premice` for datacenter category and `edge-server` and `edge-device` for edge category.
 
 
 In the Network division for the inference datacenter the file <system_desc_id>.json should also contain:

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -484,7 +484,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 
 ^1^ Optional for preview system submission. These fields must be updated in the system description json upon the public availability of the processor.
 
-^2^ The valid values for `system_type_specific` are `cloud` and `on-premice` for datacenter category and `edge-server` and `edge-device` for edge category.
+^2^ The valid values for `system_type_specific` are `cloud` and `on-premise` for datacenter category and `edge-server` and `edge-device` for edge category.
 
 
 In the Network division for the inference datacenter the file <system_desc_id>.json should also contain:

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -483,6 +483,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 |===
 
 ^1^ Optional for preview system submission. These fields must be updated in the system description json upon the public availability of the processor.
+
 ^2^ The valid values for `system_type_specific` are `cloud` and `on-premice` for datacenter category and `edge-server` and `edge-device` for edge category.
 
 

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -445,7 +445,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 | submitter | Yes | Google | David Kanter | David Kanter
 | division | Yes | closed | Closed | Open
 | system_type | Yes | datacenter | datacenter | edge
-| system_type_specific | Yes^2^ | cloud | edge-server | edge-device
+| system_type_detail | ^2^ | cloud | edge-server | edge-device
 | status | Yes | available | available | available
 |  |  |  |  |
 | system_name | Yes | tpu-v3 | 8ball | 8ball
@@ -484,7 +484,7 @@ The file <system_desc_id>.json should contain the following metadata describing 
 
 ^1^ Optional for preview system submission. These fields must be updated in the system description json upon the public availability of the processor.
 
-^2^ The valid values for `system_type_specific` are `cloud` and `on-premise` for datacenter category and `edge-server` and `edge-device` for edge category.
+^2^ Optional for submitters to add more specific system type. Some possible values for `system_type_detail` are `cloud` and `on-premise` for datacenter category and `edge-server` and `edge-device` for edge category.
 
 
 In the Network division for the inference datacenter the file <system_desc_id>.json should also contain:


### PR DESCRIPTION
Proposal to add system_type_specific field in system_desc.json file to classify edge category systems to edge-servers and edge-devices (embedded). It can also be used to classify datacenter category systems to `on-premise` and `cloud`.