### PR TITLE
Replace reference to "submitter working group" to Inference & Training.

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -254,7 +254,7 @@ The submission process defines how to submit code and results for review and eve
 
 ### Registration
 
-Submitters must register with the submitters working group and begin attending meetings at least **eight weeks before the deadline. **In order to register, a submitter or their org must sign the relevant CLA and provide primary and secondary github handles and primary and secondary POC email address.
+Submitters must register with the appropriate working group (e.g. Inference, Training) and begin attending meetings at least **eight weeks before the deadline.** In order to register, a submitter or their org must sign the relevant CLA and provide primary and secondary github handles and primary and secondary POC email address.
 
 ### How to Submit
 


### PR DESCRIPTION
The Submission Rules refers to the "submitters" working group which is now a non-existant working group (back when we had Submitters and Special Topics) prior to the refactor to Training and Inference WGs.