### PR TITLE
Experimental Tag for benchmarks

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -217,7 +217,7 @@ The exact review period schedule needs to be agreed upon 4 weeks in advance of s
 Each Working Group decides what benchmarks they want in each round.  This is a pipelined process, with the following steps:
 
 . *Carrying Capacity Decision* - Each working group decides how many benchmarks they can handle for this round.
-. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case. Optionally, working group can tag a benchmark as _experimental_ implying the benchmark is likely to be updated earlier than the otherwise expected lifetime of 2 years. The suite will have at most one benchmark with _experimental_ tag in any round.
+. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case. Optionally, working group can tag a benchmark as _experimental_ implying the benchmark is likely to be updated earlier than the otherwise expected lifetime of 2 years.
 . *Sync Domains* across working groups (e.g. Inference, Training, and HPC)
 . *Identify PIC* (person in charge) to drive this domain addition across all working groups
 . For each domain addition, do the two following steps, possibly in parallel:

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -217,7 +217,7 @@ The exact review period schedule needs to be agreed upon 4 weeks in advance of s
 Each Working Group decides what benchmarks they want in each round.  This is a pipelined process, with the following steps:
 
 . *Carrying Capacity Decision* - Each working group decides how many benchmarks they can handle for this round.
-. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case.
+. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case. Optionally, working group can tag a benchmark as _experimental_ implying the benchmark is likely to be updated earlier than the otherwise expected lifetime of 2 years. The suite will have at most one benchmark with _experimental_ tag in any round.
 . *Sync Domains* across working groups (e.g. Inference, Training, and HPC)
 . *Identify PIC* (person in charge) to drive this domain addition across all working groups
 . For each domain addition, do the two following steps, possibly in parallel:

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -217,7 +217,7 @@ The exact review period schedule needs to be agreed upon 4 weeks in advance of s
 Each Working Group decides what benchmarks they want in each round.  This is a pipelined process, with the following steps:
 
 . *Carrying Capacity Decision* - Each working group decides how many benchmarks they can handle for this round.
-. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case. Optionally, working group can tag a benchmark as _experimental_ implying the benchmark is likely to be updated earlier than the otherwise expected lifetime of 2 years.
+. *Domain Identification* - Working groups review proposals for domain adds/removals from members.  The working group will attempt to come to majority consensus in 1 or 2 meetings.  If consensus cannot be had, this will go to a vote according to the MLCommons voting rules.  Working groups may add up to 2 benchmarks max per round, but will strive for 1 or 0 as the typical case. Optionally, working group can tag a benchmark as _experimental_ implying the benchmark is likely to be updated earlier than the otherwise expected lifetime of 2 years. The suite will have at most two benchmarks with _experimental_ tag in any round.
 . *Sync Domains* across working groups (e.g. Inference, Training, and HPC)
 . *Identify PIC* (person in charge) to drive this domain addition across all working groups
 . For each domain addition, do the two following steps, possibly in parallel:


### PR DESCRIPTION
Experimental tag is a way for MLPerf to stay agile & make early bets on upcoming hot benchmarks.
It allows adopting viral benchmarks while also providing a way to update, refresh or tweak them as the ML landscape changes quickly instead of getting locked-in to a 2 year cadence. 

Ideally all benchmarks should have the agility to refresh if landscape warrants faster change e.g. update the sequence length of existing LLM models or tweak outdated architectures but we should also balance the churn to reduce submitter burden and prolong investment !/$. 