### PR TITLE
Update compatibility table for Training

### DIFF
--- a/MLPerf_Compatibility_Table.adoc
+++ b/MLPerf_Compatibility_Table.adoc
@@ -23,6 +23,7 @@ X: Change in benchmark. Submission results can be compared across rounds when th
 |RNN-T 3+|N/A |X 5+|X 2+|N/A
 |3D U-Net 3+|N/A 7+|X |N/A
 |GPT3 7+|N/A 4+|X
+|Stable Diffusionv2 8+|N/A 3+|X
 |LLama70B-LoRA 9+|N/A 2+|X
 |RGAT 9+|N/A 2+|X
 |===

--- a/MLPerf_Compatibility_Table.adoc
+++ b/MLPerf_Compatibility_Table.adoc
@@ -8,23 +8,23 @@ X: Change in benchmark. Submission results can be compared across rounds when th
 == Training
 
 |===
-|Model |0.5 |0.6 |0.7 |1.0 |1.1 |2.0 |2.1 |3.0 | 3.1 | 4.0
-|ResNet-50 v1.5 |X 9+|X 
-|SSD-ResNet34 |X 4+|X 5+|N/A 
-|RetinaNet-ResNeXt50 5+|N/A 5+|X 
-|MaskRCNN |X 8+|X |N/A 
-|NCF |X 9+|N/A 
-|NMT |X 2+|X 7+|N/A 
-|Transformer |X 2+|X 7+|N/A
-|MiniGo |X |X 5+|X 3+|N/A
-|DLRM 2+|N/A 5+|X 3+|N/A
-|DLRM-dcnv2 7+|N/A 3+|X
-|BERT 3+|N/A 7+|X 
-|RNN-T 3+|N/A |X 5+|X |N/A
-|3D U-Net 3+|N/A 7+|X
-|GPT3 7+|N/A 3+|X
-|LLama70B-LoRA 9+|N/A |X
-|RGAT 9+|N/A |X
+|Model |0.5 |0.6 |0.7 |1.0 |1.1 |2.0 |2.1 |3.0 | 3.1 | 4.0 | 4.1
+|ResNet-50 v1.5 |X 9+|X |N/A
+|SSD-ResNet34 |X 4+|X 6+|N/A 
+|RetinaNet-ResNeXt50 5+|N/A 6+|X 
+|MaskRCNN |X 8+|X 2+|N/A 
+|NCF |X 10+|N/A 
+|NMT |X 2+|X 8+|N/A 
+|Transformer |X 2+|X 8+|N/A
+|MiniGo |X |X 5+|X 4+|N/A
+|DLRM 2+|N/A 5+|X 4+|N/A
+|DLRM-dcnv2 7+|N/A 4+|X
+|BERT 3+|N/A 8+|X 
+|RNN-T 3+|N/A |X 5+|X 2+|N/A
+|3D U-Net 3+|N/A 7+|X |N/A
+|GPT3 7+|N/A 4+|X
+|LLama70B-LoRA 9+|N/A 2+|X
+|RGAT 9+|N/A 2+|X
 |===
 
 Metric: Time-to-train (measured in minutes)


### PR DESCRIPTION
1. Add v4.1 round to MLPerf Training
2. Add SD benchmark since it was missing before
