### PR TITLE
v5.0 Inference post-mortem item - Enforce requirements of bandwidth and calibration docs.

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -363,6 +363,9 @@ HPC training submissions follow the above Training directory structure except fo
 #### Inference
 
 * <submitting_organization>/
+** documentation/
+*** bandwidth_requirement.md
+*** calibration.md
 ** systems/
 *** <system_desc_id>.json   # combines hardware and software stack information
 ** code/


### PR DESCRIPTION
This PR adds further enforcement - requires calibration and bandwidth requirement documentation to be included in the inference submission. 

Inference Submission checker will need to be updated to confirm dir structure matches. 